### PR TITLE
Add support for Dock battery

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -82,6 +82,15 @@
          when the lid is open, 2 means it is accessible when the lid is
          closed.  The default is 0. -->
     <integer name="config_lidKeyboardAccessibility">1</integer>
+    
+    
+    <!-- Add support for Dock battery status indication -->
+    <bool name="config_hasDockBattery">true</bool>
+
+    <string name="config_deviceHandlersLib" translatable="false">/system/framework/com.cyanogenmod.asusdec.jar</string>
+    <string name="config_deviceDockBatteryHandlerClass" translatable="false">com.cyanogenmod.asusdec.DockBatteryHandler</string>
+    <string name="config_deviceKeyHandlerClass" translatable="false">com.cyanogenmod.asusdec.KeyHandler</string>
+    
 
     <!-- Indicate whether closing the lid causes the device to go to sleep and opening
          it causes the device to wake up.


### PR DESCRIPTION
The TF201 is not able to show the docks battery (battery in detachable keyboard).
Jorge Ruesga wrote a patch for this (see [1]), but it never made its way into the TF201 configuration. According to him the attached patch should make it work (untested). The change makes it identical to the TF300t and TF700 configurations ([2] and ]3]).

[1] http://review.cyanogenmod.org/#/c/31040/
[2] https://github.com/CyanogenMod/android_device_asus_tf300t/blob/cm-10.2/overlay/frameworks/base/core/res/res/values/config.xml
[3] https://github.com/CyanogenMod/android_device_asus_tf700t/blob/cm-10.2/overlay/frameworks/base/core/res/res/values/config.xml
